### PR TITLE
Update isa_parser.cc

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -327,7 +327,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str.substr(0, 3) == "zvl") {
       reg_t new_vlen;
       try {
-        new_vlen = std::stol(ext_str.substr(3, ext_str.size() - 4));
+        new_vlen = std::stol(ext_str.substr(3, ext_str.size() - 3));
       } catch (std::logic_error& e) {
         new_vlen = 0;
       }


### PR DESCRIPTION
# strlen of "zvl" is 3, not 4

# test
## build spike and enable vector extension
```bash
../configure --prefix=$RISCV --with-isa=RV64IMAFDCV_zicntr_zihpm_zvl512
make -j 
```
## write a test case
```c
// filename: a.c
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
int main() {
  int vlenb = 0;
  asm volatile ("csrr %0, vlenb\n\t" : "=r"(vlenb));
  printf("vlenb is %d\n", vlenb);
}
```
## compile and build the case
```bash
riscv64-unknown-elf-gcc a.c -march=rv64gcv -g -O0 -std=gnu99 -I$RISCV/sysroot/usr/include
```
## run the case
```bash
spike  pk a.out -p1 --isa=rv64imafdchv_zicntr_zihpm_zvl64  --priv=msu --hartids=0 
```

## result
```
vlenb is 64
```
